### PR TITLE
Fix timer stop state handling

### DIFF
--- a/TrialButtonAnimation/models/CountDownTimer.swift
+++ b/TrialButtonAnimation/models/CountDownTimer.swift
@@ -44,6 +44,7 @@ class CountDownTimer: ObservableObject {
     
     func stop() {
         stopAneEraseTimer()
+        isRunning = false
     }
     
     func reset(to newTime: Double) {

--- a/TrialButtonAnimationTests/models/CountDownTimerTests.swift
+++ b/TrialButtonAnimationTests/models/CountDownTimerTests.swift
@@ -85,4 +85,22 @@ final class CountDownTimerTests: XCTestCase {
         // then
         XCTAssertEqual(timer.remainTime, 1.0)
     }
+
+    func testStoppingTimerMakesRunningFlagFalse() {
+        // given
+        let timer = CountDownTimer(startTime: 1.0, intarval: 0.1)
+        timer.start()
+        let expectation = XCTestExpectation(description: "Timer running")
+        timer.$isRunning
+            .dropFirst()
+            .sink { _ in
+                expectation.fulfill()
+            }
+            .store(in: &cancellables)
+        wait(for: [expectation], timeout: 0.2)
+        // when
+        timer.stop()
+        // then
+        XCTAssertFalse(timer.isRunning)
+    }
 }


### PR DESCRIPTION
## Summary
- ensure `CountDownTimer.stop()` updates `isRunning`
- add unit test for `stop()` behaviour

## Testing
- `swiftlint` *(fails: command not found)*
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68454319c314832997940d4d46a5b536